### PR TITLE
Removed UUID random generation from database side

### DIFF
--- a/app/event/Event.scala
+++ b/app/event/Event.scala
@@ -135,15 +135,12 @@ class EventDao extends Db with LazyLogging {
 
   private val eventTable = TableQuery[EventTable]
 
-  override def setup(): IO[Unit] = {
-    for {
-      dbSetup <- super.setup()
-      tableSetup <- IO.fromFuture(IO(db.run(eventTable.schema.create)))
-    } yield tableSetup
+  override def setup(): IO[Unit] = IO.fromFuture {
+    IO(db.run(eventTable.schema.create))
   }
 
-  override def teardown(): IO[Unit] = {
-    IO.fromFuture(IO(db.run(eventTable.schema.drop)))
+  override def teardown(): IO[Unit] = IO.fromFuture {
+    IO(db.run(eventTable.schema.drop))
   }
 
   def insert(event: Event): IO[Int] = IO.fromFuture {

--- a/app/event/Event.scala
+++ b/app/event/Event.scala
@@ -23,7 +23,7 @@ object EventType extends Enumeration {
     Value
 }
 
-case class Event(uuid: Option[UUID] = Some(UUID.randomUUID()),
+final case class Event(uuid: Option[UUID] = Some(UUID.randomUUID()),
                  timestamp: DateTime = DateTime.now(),
                  `type`: EventType = EventType.UNKNOWN,
                  data: Option[JsValue] = None)

--- a/app/menu/CommandController.scala
+++ b/app/menu/CommandController.scala
@@ -7,13 +7,10 @@ import javax.inject.{Inject, Singleton}
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{AbstractController, Action, ControllerComponents}
 
-import scala.concurrent.ExecutionContext
-
 @Singleton
-class CommandController @Inject()(aggregate: Aggregate)(implicit
-  controllerComponents: ControllerComponents,
-  executionContext: ExecutionContext
-) extends AbstractController(controllerComponents) {
+class CommandController @Inject()(aggregate: Aggregate)
+  (implicit controllerComponents: ControllerComponents)
+  extends AbstractController(controllerComponents) {
 
   def createOrUpdateMenu(): Action[JsValue] = {
     Action.async(parse.json) { implicit request =>

--- a/app/menu/QueryController.scala
+++ b/app/menu/QueryController.scala
@@ -4,13 +4,10 @@ import javax.inject.{Inject, Singleton}
 import play.api.libs.json.Json
 import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
 
-import scala.concurrent.ExecutionContext
-
 @Singleton
-class QueryController @Inject()(menuViewService: MenuViewService)(implicit
-  controllerComponents: ControllerComponents,
-  executionContext: ExecutionContext
-) extends AbstractController(controllerComponents) {
+class QueryController @Inject()(menuViewService: MenuViewService)
+  (implicit controllerComponents: ControllerComponents)
+  extends AbstractController(controllerComponents) {
 
   def getMenusByNameLike(name: String): Action[AnyContent] = {
     Action.async { implicit request =>

--- a/app/menu/View.scala
+++ b/app/menu/View.scala
@@ -33,7 +33,7 @@ object MenuView {
 @Singleton
 class MenuViewService @Inject()(menuViewDao: MenuViewDao) {
 
-  def upsert(menuView: MenuView): IO[Int] = {
+  def upsert(menuView: MenuView): IO[Unit] = {
     menuViewDao.upsert(menuView)
   }
 
@@ -49,7 +49,7 @@ class MenuViewService @Inject()(menuViewDao: MenuViewDao) {
     menuViewDao.findAll()
   }
 
-  def delete(uuid: UUID): IO[Int] = {
+  def delete(uuid: UUID): IO[Unit] = {
     menuViewDao.delete(uuid)
   }
 
@@ -78,19 +78,22 @@ class MenuViewDao extends Db with LazyLogging {
 
   private val menuViewTable = TableQuery[MenuViewTable]
 
-  override def setup(): IO[Unit] = {
-    for {
-      dbSetup <- super.setup()
-      tableSetup <- IO.fromFuture(IO(db.run(sqlu"""CREATE TABLE IF NOT EXISTS #${MenuView.tableName}()""")))
-    } yield tableSetup
+  override def setup(): IO[Unit] = IO.fromFuture {
+    IO {
+      db.run(sqlu"""CREATE TABLE IF NOT EXISTS #${MenuView.tableName}()""")
+        .map(_ => ())
+    }
   }
 
-  override def teardown(): IO[Unit] = {
-    IO.fromFuture(IO(db.run(menuViewTable.schema.drop)))
+  override def teardown(): IO[Unit] = IO.fromFuture {
+    IO(db.run(menuViewTable.schema.drop))
   }
 
-  def upsert(menuView: MenuView): IO[Int] = IO.fromFuture {
-    IO(db.run(menuViewTable.insertOrUpdate(menuView)))
+  def upsert(menuView: MenuView): IO[Unit] = IO.fromFuture {
+    IO {
+      db.run(menuViewTable.insertOrUpdate(menuView))
+        .map(_ => ())
+    }
   }
 
   def findByName(name: String): IO[Seq[MenuView]] = IO.fromFuture {
@@ -117,13 +120,13 @@ class MenuViewDao extends Db with LazyLogging {
     IO(db.run(menuViewTable.result))
   }
 
-  def delete(uuid: UUID): IO[Int] = IO.fromFuture {
+  def delete(uuid: UUID): IO[Unit] = IO.fromFuture {
     IO {
       db.run {
         menuViewTable
           .filter(menuView => menuView.uuid === uuid)
           .delete
-      }
+      }.map(_ => ())
     }
   }
 
@@ -133,6 +136,7 @@ class MenuViewDao extends Db with LazyLogging {
         case "1.0" =>
           db.run(
             DBIO.seq(
+              sqlu"""CREATE EXTENSION IF NOT EXISTS "pgcrypto"""",
               sqlu"""ALTER TABLE #${MenuView.tableName} ADD COLUMN #${MenuView.uuidColumn} UUID PRIMARY KEY DEFAULT gen_random_uuid()""",
               sqlu"""ALTER TABLE #${MenuView.tableName} ADD COLUMN #${MenuView.nameColumn} TEXT UNIQUE NOT NULL DEFAULT ''""",
               sqlu"""ALTER TABLE #${MenuView.tableName} ADD COLUMN #${MenuView.ingredientsColumn} TEXT[] NOT NULL DEFAULT '{}'""",
@@ -152,6 +156,8 @@ class MenuViewDao extends Db with LazyLogging {
               sqlu"""ALTER TABLE #${MenuView.tableName} ALTER COLUMN #${MenuView.selectedCountColumn} DROP DEFAULT""",
             )
           )
+        case "3.0" =>
+          db.run(sqlu"""DROP EXTENSION IF EXISTS "pgcrypto"""").map(_ => ())
       }
     }
   }

--- a/app/menu/View.scala
+++ b/app/menu/View.scala
@@ -8,7 +8,7 @@ import javax.inject.{Inject, Singleton}
 import play.api.libs.json._
 import utils.db.Db
 
-case class MenuView(uuid: Option[UUID] = Some(UUID.randomUUID()),
+final case class MenuView(uuid: Option[UUID] = Some(UUID.randomUUID()),
                     name: String,
                     ingredients: Seq[String],
                     recipe: String,

--- a/app/menu/View.scala
+++ b/app/menu/View.scala
@@ -157,7 +157,8 @@ class MenuViewDao extends Db with LazyLogging {
             )
           )
         case "3.0" =>
-          db.run(sqlu"""DROP EXTENSION IF EXISTS "pgcrypto"""").map(_ => ())
+          db.run(sqlu"""DROP EXTENSION IF EXISTS "pgcrypto"""")
+            .map(_ => ())
       }
     }
   }

--- a/app/user/CommandController.scala
+++ b/app/user/CommandController.scala
@@ -3,23 +3,14 @@ package user
 import java.util.UUID
 
 import akka.stream.QueueOfferResult
-import auth.Auth
 import javax.inject.{Inject, Singleton}
-import play.api.Configuration
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{AbstractController, Action, ControllerComponents}
 
-import scala.concurrent.ExecutionContext
-
 @Singleton
-class CommandController @Inject()(
-  auth: Auth,
-  aggregate: Aggregate
-)(implicit
-  controllerComponents: ControllerComponents,
-  configuration: Configuration,
-  executionContext: ExecutionContext
-) extends AbstractController(controllerComponents) {
+class CommandController @Inject()(aggregate: Aggregate)
+  (implicit controllerComponents: ControllerComponents)
+  extends AbstractController(controllerComponents) {
 
   def createOrUpdateUser(): Action[JsValue] = {
     Action.async(parse.json) { implicit request =>

--- a/app/user/QueryController.scala
+++ b/app/user/QueryController.scala
@@ -7,10 +7,9 @@ import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponent
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class QueryController @Inject()(userViewService: UserViewService)(implicit
-  controllerComponents: ControllerComponents,
-  executionContext: ExecutionContext
-) extends AbstractController(controllerComponents) {
+class QueryController @Inject()(userViewService: UserViewService)
+  (implicit controllerComponents: ControllerComponents)
+  extends AbstractController(controllerComponents) {
 
   def getAllUsers(): Action[AnyContent] = {
     Action.async { implicit request =>

--- a/app/user/View.scala
+++ b/app/user/View.scala
@@ -128,7 +128,8 @@ class UserViewDao extends Db with LazyLogging {
             )
           )
         case "3.0" =>
-          db.run(sqlu"""DROP EXTENSION IF EXISTS "pgcrypto"""").map(_ => ())
+          db.run(sqlu"""DROP EXTENSION IF EXISTS "pgcrypto"""")
+            .map(_ => ())
       }
     }
   }

--- a/app/user/View.scala
+++ b/app/user/View.scala
@@ -27,7 +27,7 @@ object UserView {
 @Singleton
 class UserViewService @Inject()(userViewDao: UserViewDao) {
 
-  def upsert(userView: UserView): IO[Int] = {
+  def upsert(userView: UserView): IO[Unit] = {
     userViewDao.upsert(userView)
   }
 
@@ -39,7 +39,7 @@ class UserViewService @Inject()(userViewDao: UserViewDao) {
     userViewDao.findAll()
   }
 
-  def delete(uuid: UUID): IO[Int] = {
+  def delete(uuid: UUID): IO[Unit] = {
     userViewDao.delete(uuid)
   }
 
@@ -65,19 +65,22 @@ class UserViewDao extends Db with LazyLogging {
 
   private val userViewTable = TableQuery[UserViewTable]
 
-  override def setup(): IO[Unit] =  {
-    for {
-      dbSetup <- super.setup()
-      tableSetup <- IO.fromFuture(IO(db.run(sqlu"""CREATE TABLE IF NOT EXISTS #${UserView.tableName}()""")))
-    } yield tableSetup
+  override def setup(): IO[Unit] = IO.fromFuture {
+    IO {
+      db.run(sqlu"""CREATE TABLE IF NOT EXISTS #${UserView.tableName}()""")
+        .map(_ => ())
+    }
   }
 
   override def teardown(): IO[Unit] = IO.fromFuture {
     IO(db.run(userViewTable.schema.drop))
   }
 
-  def upsert(userView: UserView): IO[Int] = IO.fromFuture {
-    IO(db.run(userViewTable.insertOrUpdate(userView)))
+  def upsert(userView: UserView): IO[Unit] = IO.fromFuture {
+    IO{
+      db.run(userViewTable.insertOrUpdate(userView))
+        .map(_ => ())
+    }
   }
 
   def findByEmail(email: String): IO[Seq[UserView]] = IO.fromFuture {
@@ -94,13 +97,13 @@ class UserViewDao extends Db with LazyLogging {
     IO(db.run(userViewTable.result))
   }
 
-  def delete(uuid: UUID): IO[Int] = IO.fromFuture {
+  def delete(uuid: UUID): IO[Unit] = IO.fromFuture {
     IO {
       db.run {
         userViewTable
           .filter(menuView => menuView.uuid === uuid)
           .delete
-      }
+      }.map(_ => ())
     }
   }
 
@@ -110,6 +113,7 @@ class UserViewDao extends Db with LazyLogging {
         case "1.0" =>
           db.run(
             DBIO.seq(
+              sqlu"""CREATE EXTENSION IF NOT EXISTS "pgcrypto"""",
               sqlu"""ALTER TABLE #${UserView.tableName} ADD COLUMN #${UserView.uuidColumn} UUID PRIMARY KEY DEFAULT gen_random_uuid()""",
               sqlu"""ALTER TABLE #${UserView.tableName} ADD COLUMN #${UserView.nameColumn} TEXT DEFAULT '' NOT NULL""",
               sqlu"""ALTER TABLE #${UserView.tableName} ADD COLUMN #${UserView.emailColumn} TEXT UNIQUE DEFAULT '' NOT NULL"""
@@ -123,6 +127,8 @@ class UserViewDao extends Db with LazyLogging {
               sqlu"""ALTER TABLE #${UserView.tableName} ALTER COLUMN #${UserView.emailColumn} DROP DEFAULT"""
             )
           )
+        case "3.0" =>
+          db.run(sqlu"""DROP EXTENSION IF EXISTS "pgcrypto"""").map(_ => ())
       }
     }
   }

--- a/app/user/View.scala
+++ b/app/user/View.scala
@@ -8,7 +8,7 @@ import javax.inject.{Inject, Singleton}
 import play.api.libs.json.Json
 import utils.db.Db
 
-case class UserView(uuid: Option[UUID] = Some(UUID.randomUUID()),
+final case class UserView(uuid: Option[UUID] = Some(UUID.randomUUID()),
                     name: String,
                     email: String)
 

--- a/app/utils/EmailSender.scala
+++ b/app/utils/EmailSender.scala
@@ -7,7 +7,7 @@ import javax.inject.Singleton
 import javax.mail.internet.{InternetAddress, MimeMessage}
 import javax.mail.{Address, Message, Session}
 
-case class Email(emails: Array[String], subject: String, message: String)
+final case class Email(emails: Array[String], subject: String, message: String)
 
 @Singleton
 class EmailSender {

--- a/app/utils/db/Db.scala
+++ b/app/utils/db/Db.scala
@@ -6,16 +6,12 @@ import slick.jdbc.JdbcProfile
 
 trait Db {
   private val dbConfig = DatabaseConfig.forConfig[JdbcProfile]("postgres")
-  val db = dbConfig.db
 
-  import utils.db.PostgresProfile.api._
+  protected val db = dbConfig.db
 
-  implicit val executor = db.ioExecutionContext
+  protected implicit val ioExecutor = db.ioExecutionContext
 
-  def setup(): IO[Unit] = {
-    //TODO: this needs to be removed once we make UUID generation to app level
-    IO.fromFuture(IO(db.run(sqlu"""CREATE EXTENSION IF NOT EXISTS "pgcrypto"""").map(_ => ())))
-  }
+  def setup(): IO[Unit]
 
   def teardown(): IO[Unit]
 }

--- a/test/menu/CommandControllerTest.scala
+++ b/test/menu/CommandControllerTest.scala
@@ -61,10 +61,12 @@ class CommandControllerTest extends FlatSpec
     menuViewDao.setup().unsafeRunSync()
     menuViewDao.evolve("1.0").unsafeRunSync()
     menuViewDao.evolve("2.0").unsafeRunSync()
+    menuViewDao.evolve("3.0").unsafeRunSync()
 
     userViewDao.setup().unsafeRunSync()
     userViewDao.evolve("1.0").unsafeRunSync()
     userViewDao.evolve("2.0").unsafeRunSync()
+    userViewDao.evolve("3.0").unsafeRunSync()
   }
 
   after {


### PR DESCRIPTION
clear separation of application and database becomes vague once database start doing things applications are supposed to do. UUID generation should be done in application side, not database side, and this makes testability tricky if we rely solely on database's logic.

Schema change still needs to be done by database evolution request to running server

resolve #44 